### PR TITLE
docs: update repository structure instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,14 +40,10 @@ This is a **documentation and tutorials repository** for the FountainAI ecosyste
   - **TIMEOUT WARNING**: If attempting builds, expect 10+ minutes before failure. NEVER CANCEL during dependency resolution.
 
 ### Repository Structure
-```
-.
-├── README.md                    # Main documentation and workflow instructions  
-├── Building-A-Mac-Screenplay-Editor/
-│   └── Building a macOS...pdf   # Comprehensive PDF tutorial
-├── .gitignore                   # Standard Swift/macOS ignores
-└── LICENSE                      # MIT License
-```
+
+Tutorial content lives under the `tutorials/` directory.
+PDF resources, such as comprehensive guides, reside at the repository root.
+Run `ls` or `find` to discover current tutorials.
 
 ## Validation and Testing
 


### PR DESCRIPTION
## Summary
- streamline repository structure guidance
- encourage using `ls` or `find` to discover current tutorials

## Testing
- `npx --yes markdownlint-cli .github/copilot-instructions.md` *(fails: multiple style warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68c129cff2448333a0330d8c377045fc