### PR TITLE
docs: clarify Swift toolchain prerequisites

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,8 +10,7 @@ This is a **documentation and tutorials repository** for the FountainAI ecosyste
 ## Working Effectively
 
 ### Prerequisites and Environment Setup
-- Swift 6.1+ is already installed and available at `/usr/local/bin/swift`
-- Swift Package Manager is included with Swift toolchain
+- Swift toolchain and Swift Package Manager are available in the PATH; verify with `swift --version`
 - macOS 14+ is referenced in docs but Linux environment works for basic Swift operations
 - No additional SDK downloads required for basic Swift development
 


### PR DESCRIPTION
## Summary
- clarify that Swift toolchain and Swift Package Manager are available in PATH
- mention verifying with `swift --version`

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_b_68c12b763b988333b418e7f80895044e