### PR TITLE
Add tutorial setup script and wrappers

### DIFF
--- a/Scripts/setup-tutorial.sh
+++ b/Scripts/setup-tutorial.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# setup-tutorial.sh — scaffold tutorial app files from the FountainAI repo
+# Usage: Scripts/setup-tutorial.sh <AppName> [BundleID]
+
+APP_NAME="${1:-}"
+BUNDLE_ID="${2:-}"
+
+if [[ -z "$APP_NAME" ]]; then
+  echo "Usage: $(basename "$0") <AppName> [BundleID]" >&2
+  exit 2
+fi
+
+TARGET_DIR="$(pwd)"
+TMP_DIR="$(mktemp -d)"
+REPO_DIR="$TMP_DIR/the-fountainai"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+if [[ ! -d "$REPO_DIR" ]]; then
+  git clone --depth 1 https://github.com/Fountain-Coach/the-fountainai.git "$REPO_DIR" >/dev/null
+fi
+
+pushd "$REPO_DIR" >/dev/null
+if [[ -n "$BUNDLE_ID" ]]; then
+  Scripts/new-gui-app.sh "$APP_NAME" "$BUNDLE_ID"
+else
+  Scripts/new-gui-app.sh "$APP_NAME"
+fi
+popd >/dev/null
+
+cp "$REPO_DIR/apps/$APP_NAME/main.swift" "$TARGET_DIR/"
+cp "$REPO_DIR/Package.swift" "$TARGET_DIR/"
+
+echo "Generated main.swift and Package.swift in $TARGET_DIR"

--- a/tutorials/01-hello-fountainai/setup.sh
+++ b/tutorials/01-hello-fountainai/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Usage: ./setup.sh [BundleID]
+../../Scripts/setup-tutorial.sh HelloFountainAI "$@"

--- a/tutorials/02-basic-ui-teatro/setup.sh
+++ b/tutorials/02-basic-ui-teatro/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Usage: ./setup.sh [BundleID]
+../../Scripts/setup-tutorial.sh BasicTeatro "$@"

--- a/tutorials/03-data-persistence-fountainstore/setup.sh
+++ b/tutorials/03-data-persistence-fountainstore/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Usage: ./setup.sh [BundleID]
+../../Scripts/setup-tutorial.sh FountainStore "$@"

--- a/tutorials/04-multimedia-midi2/setup.sh
+++ b/tutorials/04-multimedia-midi2/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Usage: ./setup.sh [BundleID]
+../../Scripts/setup-tutorial.sh Midi2 "$@"

--- a/tutorials/05-ai-integration-openapi/setup.sh
+++ b/tutorials/05-ai-integration-openapi/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Usage: ./setup.sh [BundleID]
+../../Scripts/setup-tutorial.sh OpenAPI "$@"

--- a/tutorials/06-screenplay-editor-capstone/setup.sh
+++ b/tutorials/06-screenplay-editor-capstone/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Usage: ./setup.sh [BundleID]
+../../Scripts/setup-tutorial.sh ScreenplayEditor "$@"


### PR DESCRIPTION
## Summary
- Add `Scripts/setup-tutorial.sh` to scaffold tutorial Swift packages from the FountainAI repository
- Provide `setup.sh` wrappers for each tutorial to invoke the new script with the appropriate app name

## Testing
- `bash -n Scripts/setup-tutorial.sh`
- `bash -n tutorials/*/setup.sh`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c19eeca12483339a343e5e4aa383bb