### PR TITLE
Use setup script across tutorials

### DIFF
--- a/tutorials/01-hello-fountainai/README.md
+++ b/tutorials/01-hello-fountainai/README.md
@@ -3,29 +3,23 @@
 Follow these steps to spin up a minimal FountainAI app.
 
 ## 1. Check your environment
-Run the monorepo's self-check script to ensure Swift builds and tests succeed:
+Verify Swift is installed:
 
 ```bash
-Scripts/selfcheck.sh
+swift --version
 ```
 
 ## 2. Scaffold the app
-Generate a starter SwiftUI target:
+Run the provided setup script, which pulls in the FountainAI app-creation template from the [the-fountainai](https://github.com/Fountain-Coach/the-fountainai) repo:
 
 ```bash
-Scripts/new-gui-app.sh HelloFountainAI
+./setup.sh
 ```
 
 ## 3. Build and run
 Build the project and launch it locally:
 
 ```bash
-Scripts/build-local.sh
-scripts/start-local.sh HelloFountainAI
+swift build
+swift run
 ```
-
-## Script references
-- [selfcheck.sh](https://github.com/Fountain-Coach/the-fountainai/blob/main/Scripts/selfcheck.sh)
-- [new-gui-app.sh](https://github.com/Fountain-Coach/the-fountainai/blob/main/Scripts/new-gui-app.sh)
-- [build-local.sh](https://github.com/Fountain-Coach/the-fountainai/blob/main/Scripts/build-local.sh)
-- [start-local.sh](https://github.com/Fountain-Coach/the-fountainai/blob/main/scripts/start-local.sh)

--- a/tutorials/02-basic-ui-teatro/README.md
+++ b/tutorials/02-basic-ui-teatro/README.md
@@ -3,10 +3,10 @@
 This guide shows how to modify the scaffolded user interface using FountainAI's Teatro domain-specific language (DSL).
 
 ## 1. Scaffold the project
-Generate a GUI app template:
+Run the setup script, which pulls in the FountainAI app-creation template from the [the-fountainai](https://github.com/Fountain-Coach/the-fountainai) repo:
 
 ```bash
-Scripts/new-gui-app.sh BasicTeatro
+./setup.sh
 ```
 
 The script creates a starter project with a `MainScene.teatro` file that declares the UI.
@@ -38,11 +38,6 @@ When you press the button, the handler runs and prints to the console.
 Compile the project and launch the generated SwiftUI app:
 
 ```bash
-Scripts/build-local.sh
-scripts/start-local.sh BasicTeatro
+swift build
+swift run
 ```
-
-## Script references
-- [new-gui-app.sh](https://github.com/Fountain-Coach/the-fountainai/blob/main/Scripts/new-gui-app.sh)
-- [build-local.sh](https://github.com/Fountain-Coach/the-fountainai/blob/main/Scripts/build-local.sh)
-- [start-local.sh](https://github.com/Fountain-Coach/the-fountainai/blob/main/scripts/start-local.sh)

--- a/tutorials/03-data-persistence-fountainstore/README.md
+++ b/tutorials/03-data-persistence-fountainstore/README.md
@@ -2,7 +2,14 @@
 
 This tutorial demonstrates how to persist simple data using **FountainStore**. You will create a minimal `Note` model, save instances, and load them back into memory.
 
-## 1. Define a data model
+## 1. Scaffold the project
+Run the setup script, which uses the FountainAI app-creation template from the [the-fountainai](https://github.com/Fountain-Coach/the-fountainai) repo:
+
+```bash
+./setup.sh
+```
+
+## 2. Define a data model
 Create a struct conforming to `Codable` so it can be serialized to disk:
 
 ```swift
@@ -12,14 +19,14 @@ struct Note: Codable, Identifiable {
 }
 ```
 
-## 2. Initialize the store
+## 3. Initialize the store
 Instantiate a store that writes to a JSON file:
 
 ```swift
 let store = FountainStore<Note>(filename: "notes.json")
 ```
 
-## 3. Save a note
+## 4. Save a note
 Construct a new note and persist it:
 
 ```swift
@@ -27,14 +34,14 @@ let note = Note(id: UUID(), text: "Remember the milk")
 try store.save(note)
 ```
 
-## 4. Load all notes
+## 5. Load all notes
 Retrieve every note stored on disk:
 
 ```swift
 let notes: [Note] = try store.load()
 ```
 
-## 5. Retrieve a specific note
+## 6. Retrieve a specific note
 Find a note by its identifier after loading:
 
 ```swift
@@ -44,4 +51,12 @@ if let first = notes.first(where: { $0.id == note.id }) {
 ```
 
 With these building blocks you can manage persistent collections of notes in your FountainAI apps.
+
+## Build and run
+Compile and execute the package:
+
+```bash
+swift build
+swift run
+```
 

--- a/tutorials/04-multimedia-midi2/README.md
+++ b/tutorials/04-multimedia-midi2/README.md
@@ -2,6 +2,13 @@
 
 This tutorial shows how to play audio and keep your user interface synchronized with MIDI 2.0 data.
 
+## Scaffold the project
+Run the setup script, which uses the FountainAI app-creation template from the [the-fountainai](https://github.com/Fountain-Coach/the-fountainai) repo:
+
+```bash
+./setup.sh
+```
+
 ## Playing Audio
 
 Load a MIDI file and route it into an `AudioContext`. The player will handle decoding and playback once `play()` is called:
@@ -46,3 +53,11 @@ Hook simple controls into the player with standard DOM events:
 ```
 
 These snippets demonstrate how audio playback and UI synchronization can be achieved using MIDI 2.0.
+
+## Build and run
+Compile and launch the project:
+
+```bash
+swift build
+swift run
+```

--- a/tutorials/05-ai-integration-openapi/README.md
+++ b/tutorials/05-ai-integration-openapi/README.md
@@ -2,14 +2,21 @@
 
 Learn how to call FountainAI services from any HTTP client by using its OpenAPI endpoints.
 
-## 1. Get API access
+## 1. Scaffold the project
+Run the setup script, which uses the FountainAI app-creation template from the [the-fountainai](https://github.com/Fountain-Coach/the-fountainai) repo:
+
+```bash
+./setup.sh
+```
+
+## 2. Get API access
 Create an account and generate an API key, then expose it to your environment:
 
 ```bash
 export FOUNTAIN_AI_KEY="sk-your-key"
 ```
 
-## 2. Invoke an AI endpoint
+## 3. Invoke an AI endpoint
 Send a POST request to the `/v1/generate` path with the desired model and prompt.
 
 ### cURL example
@@ -48,6 +55,14 @@ let task = URLSession.shared.dataTask(with: request) { data, _, _ in
     }
 }
 task.resume()
+```
+
+## Build and run
+Compile and run the package:
+
+```bash
+swift build
+swift run
 ```
 
 ## Next steps

--- a/tutorials/06-screenplay-editor-capstone/README.md
+++ b/tutorials/06-screenplay-editor-capstone/README.md
@@ -2,6 +2,13 @@
 
 This capstone combines UI, persistence, multimedia, and AI features to form a simple screenplay editor.
 
+## Setup
+Run the setup script, which uses the FountainAI app-creation template from the [the-fountainai](https://github.com/Fountain-Coach/the-fountainai) repo:
+
+```bash
+./setup.sh
+```
+
 ## UI with Teatro
 The interface layout is defined in [MainScene.teatro](./MainScene.teatro). Buttons emit events that trigger saving notes, playing cues, and requesting AI help.
 
@@ -21,3 +28,11 @@ The interface layout is defined in [MainScene.teatro](./MainScene.teatro). Butto
 - `AIClient.swift` processes `ask-ai` and its results can be stored via the note store.
 
 For a detailed end-to-end build, consult the [PDF guide](./Building%20a%20macOS%20Screenplay%20Editor%20with%20Teatro%2C%20FountainAI%2C%20and%20MIDI2.pdf).
+
+## Build and run
+Compile and launch the project:
+
+```bash
+swift build
+swift run
+```


### PR DESCRIPTION
## Summary
- Replace external tooling references with local `setup.sh` in all tutorials, noting it pulls from the `the-fountainai` app template.
- Update build/run guidance to use `swift build` and `swift run`.

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_b_68c1a041c940833387850757ec7c326f