### PR TITLE
Document setup script behavior in tutorial

### DIFF
--- a/tutorials/01-hello-fountainai/README.md
+++ b/tutorials/01-hello-fountainai/README.md
@@ -42,6 +42,13 @@ Run the provided setup script, which pulls in the FountainAI app-creation templa
 ./setup.sh
 ```
 
+The script clones the template repository into a temporary folder and runs its
+`new-gui-app` helper to scaffold the **HelloFountainAI** target. It then copies
+the generated `main.swift` and `Package.swift` into this tutorial directory and
+prints status messages such as where the files were written. By default it runs
+non‑interactively, so no prompts appear unless you pass a custom bundle
+identifier as an argument.
+
 ## 3. Build and run
 Build the project and launch it locally:
 


### PR DESCRIPTION
## Summary
- Clarify what `setup.sh` does in the Hello FountainAI tutorial, including repository download, generated files, and absence of prompts.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c1a81d541883339e0e027d0f7542f7