### PR TITLE
Add Codex prompt for Hello FountainAI tutorial

### DIFF
--- a/tutorials/01-hello-fountainai/agent.md
+++ b/tutorials/01-hello-fountainai/agent.md
@@ -1,0 +1,11 @@
+You are Codex, an autonomous developer.
+Your goal is to complete the "Hello FountainAI" tutorial automatically.
+
+Steps:
+1. Confirm required tools are installed by running `swift --version` and `git --version`.
+2. Ensure `setup.sh` is executable (`chmod +x setup.sh`) and run it to scaffold the starter app.
+3. Build the project with `swift build` and run it with `swift run`. The console should print "Hello, FountainAI!".
+4. Edit the generated `main.swift` to replace the greeting line `print("Hello, FountainAI!")` with `print("Hello from Codex!")`.
+5. Rebuild and run again to display the new greeting.
+
+Return any output from these steps and report completion when the custom greeting is shown.


### PR DESCRIPTION
## Summary
- Add agent.md containing Codex prompt to automate the Hello FountainAI tutorial steps

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c1b24343448333bd8e6f4f0b37d5b8