### PR TITLE
feat: trigger Csound tone on launch

### DIFF
--- a/Sources/HelloCsound/main.swift
+++ b/Sources/HelloCsound/main.swift
@@ -1,8 +1,20 @@
 import Foundation
 
-do {
-    let samples = try CsoundPlayer().play()
-    print("Generated \(samples.count) samples from hello.csd")
-} catch {
-    print("Playback failed: \(error)")
+func playTone() {
+    do {
+        let samples = try CsoundPlayer().play()
+        print("Generated \(samples.count) samples from hello.csd")
+    } catch {
+        print("Playback failed: \(error)")
+    }
+}
+
+// Play tone on launch
+playTone()
+
+// Allow user to trigger tone again via input
+print("Press Enter to play again or type q to quit.")
+while let input = readLine(), input.isEmpty {
+    playTone()
+    print("Press Enter to play again or type q to quit.")
 }

--- a/tutorials/01-hello-csound/setup.sh
+++ b/tutorials/01-hello-csound/setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Usage: ./setup.sh [BundleID]
+../../Scripts/setup-tutorial.sh HelloCsound "$@"
+
+# Ensure the Csound file is present in the generated package
+mkdir -p Sources/HelloCsound
+cp hello.csd Sources/HelloCsound/hello.csd


### PR DESCRIPTION
## Summary
- instantiate CsoundPlayer at startup and allow replay on user input
- copy `hello.csd` into the local package during tutorial setup

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68c7b92433a88333819d07a4f5af7a32