### PR TITLE
docs: expand module 05 swiftcurseskit guidance

### DIFF
--- a/docs/tutor/modules/05-tools-factory-to-function-caller.md
+++ b/docs/tutor/modules/05-tools-factory-to-function-caller.md
@@ -3,23 +3,35 @@
 **Outcome**: Register a tool from an OpenAPI operation; invoke it via Function Caller; persist results.
 
 ## What you’ll ship
-A tool registration pane (by `operationId`) and an invocation panel with result history.
+An end-to-end tool management workflow inside `swiftcurseskit`:
+
+- A curses-based tool registration pane that binds `operationId` entries from Tools Factory to shared view models.
+- An invocation panel that calls Function Caller endpoints and streams output into a scrolling results history buffer.
+- Terminal UI rendering that surfaces past results inline (status, timestamp, payload excerpts) so operators can review history without leaving the curses session.
 
 ## Specs to read
 - `openapi/tools-factory.yml`
 - `openapi/function-caller.yml`
 - `openapi/persist.yml`
 
-## Behavioral acceptance
+## Behavioral Acceptance
 - [ ] Register operations in Tools Factory
-- [ ] Tools appear in catalog and are invokable by `operationId`
+- [ ] Tools appear in the curses catalog pane and are invokable by `operationId`
+- [ ] Cursor navigation toggles between catalog and invocation panes with visible focus cues
+- [ ] Invocation pane exposes keyboard shortcuts (e.g., `r`) to rerun the highlighted tool without re-registering
+- [ ] Results history refreshes on a fixed cadence (e.g., every poll tick) and renders within the curses UI without tearing
 - [ ] Results persisted in corpus with links back to tool invocation
 
-## Test plan
+## Test Plan
 - Validate tool registration lifecycle and result persistence
+- Exercise curses navigation between catalog and invocation panes (arrow keys, tab cycling)
+- Verify rerun shortcuts dispatch Function Caller requests using the cached registration metadata
+- Confirm results history refresh cadence matches the configured poll interval and reflects new corpus entries
 
 ## Runbook
-- Configure Tools Factory and Function Caller URLs
+- Configure Tools Factory and Function Caller URLs, wiring them into the shared `swiftcurseskit` view models used by both panes
+- Ensure invocation responses append to the persistent results history buffer rendered in the curses interface
+- Monitor poll cadence to keep the results history synchronized without flicker; adjust timer intervals if rendering lags
 
 ## Hand-off to Codex
-> Implement tool registration from spec and invocation via Function Caller; store outputs in corpus.
+> Wire Tools Factory and Function Caller endpoints into the shared `swiftcurseskit` view models, implement the curses panes for registration/invocation, and persist invocation outputs to the on-screen history and corpus.


### PR DESCRIPTION
## Summary
- detail swiftcurseskit registration and invocation panels, including history rendering guidance
- add curses-specific acceptance criteria and test steps while retaining API validations
- update runbook and hand-off instructions to wire shared view models and persist outputs in the curses UI

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_b_68cf866daf208333a8a29c46a0980cfd