### PR TITLE
docs: expand module 07 curses guidance

### DIFF
--- a/docs/tutor/modules/07-observability-and-guards.md
+++ b/docs/tutor/modules/07-observability-and-guards.md
@@ -1,23 +1,26 @@
 # Module 07 — Observability & Guards
 
-**Outcome**: Add gateway plugins (budget, rate-limit, destructive-ops guard) and visualize their effects.
+**Outcome**: Extend the Swift curses dashboard with live widgets that surface gateway budgets, rate limits, and guard prompts in-line with operator workflows.
 
 ## What you’ll ship
-Controls and indicators for budget/rate-limit states; explicit flows for destructive operations.
+Swift `swiftcurseskit` indicators that paint budget/rate-limit states, prompt overlays for destructive operations, and guard status banners that refresh alongside the terminal dashboard.
 
 ## Specs to read
 - Gateway OpenAPIs: budget breaker, rate limiter, destructive operations guard, security sentinel
 
 ## Behavioral acceptance
-- [ ] Budget/Rate-limit decisions observable in responses/headers and surfaced in UI
-- [ ] Sensitive calls require explicit approval and are gated accordingly
-- [ ] Metrics available via `/metrics` or equivalent endpoints
+- [ ] Gateway budget and rate-limit headers are polled on the curses dashboard cadence and update the corresponding widgets without flicker
+- [ ] Sensitive/destructive calls require keyboard confirmation within the curses prompt and block until the gateway guard approves
+- [ ] Guard alerts render as terminal overlays that clear on acknowledgment while the API response metadata remains visible for audit
+- [ ] Metrics remain available via `/metrics` or equivalent endpoints for downstream collectors
 
 ## Test plan
-- Simulate throttling and verify UX clarity
+- Exercise simulated throttling to verify curses indicators reflect header changes and API responses stay correct
+- Trigger guard rails to confirm keyboard confirmation flows mirror gateway decisions and that API contracts remain honored
 
 ## Runbook
-- Ensure gateway base URLs are configured; propagate headers/metadata to the GUI layer
+- Configure gateway base URLs and route response headers/metadata into `swiftcurseskit` data sources feeding the dashboard widgets
+- Persist and rehydrate operator prompts within the curses UI so guard dialogues survive screen refreshes and reconnects
 
 ## Hand-off to Codex
-> Integrate gateway decisions into UX, including guard rails and operator prompts.
+> Wire gateway metadata into the Swift terminal UI via `swiftcurseskit` components and maintain operator prompts end-to-end in the curses experience.


### PR DESCRIPTION
## Summary
- align Module 07 outcome and deliverables around Swift curses dashboard widgets for gateway budgets, limits, and guards
- extend acceptance and test coverage lists with curses behaviors while preserving API expectations
- update runbook and hand-off guidance to route gateway metadata into swiftcurseskit components and maintain operator prompts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cf86eb481483339be7cfd5f2d7e070