### PR TITLE
docs: document curses stream viewer requirements

### DIFF
--- a/docs/tutor/modules/08-reasoning-streams-midi2-optional.md
+++ b/docs/tutor/modules/08-reasoning-streams-midi2-optional.md
@@ -3,21 +3,27 @@
 **Outcome**: Stream planner/awareness events as SSE-over-MIDI for transparency; add basic transport controls.
 
 ## What you’ll ship
-A live stream panel that displays reasoning events and lets users start/stop playback.
+A Swift `swiftcurseskit` dashboard that renders the SSE-over-MIDI stream viewer in the left pane with event metadata on the right, anchored by a status bar showing transport state and connection health. The dashboard must map keyboard controls (`space` toggles play/pause, `r` rewinds to the first event, `n` steps to the next event) and surface on-screen hints so terminal users discover the bindings.
 
 ## Specs to read
 - Planner/Awareness streaming endpoints
 - MIDI2 transport interfaces (consumer side)
 
 ## Behavioral acceptance
-- [ ] Live stream appears with event sequencing; transport works (play/stop/replay)
+- [ ] Live stream appears with event sequencing; transport works (play/stop/replay) via documented keyboard controls
+- [ ] Curses dashboard redraws at the configured cadence without frame tearing and survives terminal resize events
 - [ ] No out-of-spec/private calls; only documented streaming endpoints
 
 ## Test plan
 - Fixture-based stream playback and UI timeline assertions
+- Curses transport harness that sends keyboard events (`space`, `r`, `n`) and asserts transport state transitions
+- Integration test that exercises redraw cadence (e.g., 250 ms ticker) and verifies layout recovery after simulated `SIGWINCH`
 
 ## Runbook
-- Configure stream endpoints and MIDI client per environment constraints
+- Bind planner and awareness SSE endpoints to `swiftcurseskit` stream widgets via the MIDI2 client adapter; confirm the MIDI client identifier matches the terminal session and is discoverable to the OS MIDI stack.
+- Export `MIDI_CLIENT_NAME` (or platform equivalent) before launching the curses dashboard so the MIDI2 bridge registers correctly, then `swift run` the module with terminal colors enabled.
+- Validate the dashboard by connecting to staging endpoints first, watching the transport status bar for latency/backpressure indicators, and only then switch to production URLs.
+- Document the expected keyboard shortcuts in the deployment notes so on-call engineers can triage from an SSH session without a pointing device.
 
 ## Hand-off to Codex
-> Implement a basic event stream viewer backed by documented streaming endpoints; attach MIDI transport.
+> Implement a curses-native event stream viewer that wires planner/awareness SSE endpoints into `swiftcurseskit` components, includes keyboard transport controls, and configures the MIDI client for terminal execution.


### PR DESCRIPTION
## Summary
- describe the Swift swiftcurseskit dashboard layout for the SSE-over-MIDI stream viewer and keyboard bindings
- add curses-aware acceptance criteria and tests alongside the streaming validations
- expand runbook and hand-off notes for wiring planner/awareness streams to swiftcurseskit and configuring the MIDI client

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_b_68cf86f9bfa883339bc895b28e82ae02