### PR TITLE
docs: add curses ui acceptance checklist

### DIFF
--- a/docs/tutor/_includes/testing-checklists.md
+++ b/docs/tutor/_includes/testing-checklists.md
@@ -18,6 +18,12 @@ Use these recurring checklists across modules:
 - [ ] GUI issues only HTTP requests against documented OpenAPI operations
 - [ ] Missing capabilities are surfaced with actionable messaging (no crashes)
 
+## Curses UI
+- [ ] Refresh cadence stays aligned with the `swiftcurseskit` render loop so screens reuse the shared throttling instead of hand-rolled timers
+- [ ] Keyboard navigation hooks into the `swiftcurseskit` shortcut maps; module-specific keys are layered on top without overriding core bindings
+- [ ] Focus management defers to the `swiftcurseskit` focus stack so only one pane or form captures input and tab/arrow order remains deterministic
+- [ ] Redraw stability matches `swiftcurseskit` double-buffer expectations—no flicker, ghosting, or partial updates when data streams in
+
 ## Observability & Guards
 - [ ] Budget/Rate limit decisions observable in responses/headers
 - [ ] Destructive operations require explicit guard approval paths


### PR DESCRIPTION
## Summary
- document curses UI-specific expectations in the shared testing checklist
- align refresh, navigation, focus, and redraw guidance with swiftcurseskit behaviors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cf870484bc8333b7f103ad1809306e